### PR TITLE
Avoid script exit when grep returns non 0 status in old bash versions

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -468,7 +468,7 @@ update_profile() {
     printf "\n$path_str\n"
     return 1
   else
-    if ! command grep -qc 'GETMESH_HOME' "$detected_profile"; then
+    if ! (command grep -qc 'GETMESH_HOME' "$detected_profile"); then
       log_info "updating user profile ($detected_profile)..."
       log_info "the following two lines are added into your profile ($detected_profile):" 
       printf "\n$path_str\n"


### PR DESCRIPTION
Solves #63
`errexit` bash flag casuse the script to exit when the current profile is checked for already installed GETMESH_HOME because tested command are not handled correctly. They shouldn't exit the script, for more info check https://github.com/tetratelabs/getmesh/issues/63#issuecomment-903940907.