### PR TITLE
Fix getmesh fetchistioctl darwin arm64

### DIFF
--- a/internal/istioctl/istioctl.go
+++ b/internal/istioctl/istioctl.go
@@ -292,7 +292,6 @@ func fetchIstioctlURL(targetDistribution *manifest.IstioDistribution, runtimeGOO
 
 	if runtimeGOARCH == "arm64" {
 		return fmt.Sprintf(istioctlDownloadURLFormatWithArch, targetDistribution.String(), "osx", runtimeGOARCH)
-	} else {
-		return fmt.Sprintf(istioctlDownloadURLFormatWithoutArch, targetDistribution.String(), "osx")
 	}
+	return fmt.Sprintf(istioctlDownloadURLFormatWithoutArch, targetDistribution.String(), "osx")
 }

--- a/internal/istioctl/istioctl.go
+++ b/internal/istioctl/istioctl.go
@@ -286,15 +286,13 @@ func fetchIstioctlURL(targetDistribution *manifest.IstioDistribution, runtimeGOO
 		istioctlDownloadURLFormatWithoutArch = "https://istio.tetratelabs.io/getmesh/files/istio-%s-%s.tar.gz"
 	)
 
-	var url string
 	if runtimeGOOS != "darwin" {
-		url = fmt.Sprintf(istioctlDownloadURLFormatWithArch, targetDistribution.String(), runtimeGOOS, runtimeGOARCH)
-		return url
+		return fmt.Sprintf(istioctlDownloadURLFormatWithArch, targetDistribution.String(), runtimeGOOS, runtimeGOARCH)
 	}
+
 	if runtimeGOARCH == "arm64" {
-		url = fmt.Sprintf(istioctlDownloadURLFormatWithArch, targetDistribution.String(), "osx", runtimeGOARCH)
+		return fmt.Sprintf(istioctlDownloadURLFormatWithArch, targetDistribution.String(), "osx", runtimeGOARCH)
 	} else {
-		url = fmt.Sprintf(istioctlDownloadURLFormatWithoutArch, targetDistribution.String(), "osx")
+		return fmt.Sprintf(istioctlDownloadURLFormatWithoutArch, targetDistribution.String(), "osx")
 	}
-	return url
 }

--- a/internal/istioctl/istioctl_test.go
+++ b/internal/istioctl/istioctl_test.go
@@ -519,9 +519,7 @@ func TestFetchIstioctlURL(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := fetchIstioctlURL(tc.istioDistribution, tc.goos, tc.goarch)
-			if tc.want != got {
-				t.Fatalf("expected: %v, got: %v", tc.want, got)
-			}
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/istioctl/istioctl_test.go
+++ b/internal/istioctl/istioctl_test.go
@@ -378,6 +378,16 @@ func TestFetch(t *testing.T) {
 	ms := &manifest.Manifest{
 		IstioDistributions: []*manifest.IstioDistribution{
 			{
+				Version:       "1.10.3",
+				Flavor:        manifest.IstioDistributionFlavorTetrate,
+				FlavorVersion: 0,
+			},
+			{
+				Version:       "1.10.3",
+				Flavor:        manifest.IstioDistributionFlavorTetrateFIPS,
+				FlavorVersion: 0,
+			},
+			{
 				Version:       "1.7.6",
 				Flavor:        manifest.IstioDistributionFlavorTetrate,
 				FlavorVersion: 0,
@@ -407,8 +417,8 @@ func TestFetch(t *testing.T) {
 
 	t.Run("supported", func(t *testing.T) {
 		for _, c := range []*manifest.IstioDistribution{
-			{Version: "1.7.5", Flavor: manifest.IstioDistributionFlavorTetrate, FlavorVersion: 0},
-			{Version: "1.7.6", Flavor: manifest.IstioDistributionFlavorTetrate, FlavorVersion: 0},
+			{Version: "1.10.3", Flavor: manifest.IstioDistributionFlavorTetrate, FlavorVersion: 0},
+			{Version: "1.10.3", Flavor: manifest.IstioDistributionFlavorTetrateFIPS, FlavorVersion: 0},
 		} {
 			require.Error(t, checkExist(dir, c))
 			err = Fetch(dir, c, ms)

--- a/internal/istioctl/istioctl_test.go
+++ b/internal/istioctl/istioctl_test.go
@@ -461,3 +461,57 @@ func TestFetch(t *testing.T) {
 		}
 	})
 }
+
+func TestFetchIstioctlURL(t *testing.T) {
+	istioDistribution := &manifest.IstioDistribution{
+		Version:       "1.7.6",
+		Flavor:        manifest.IstioDistributionFlavorTetrate,
+		FlavorVersion: 0,
+	}
+
+	tests := map[string]struct {
+		istioDistribution *manifest.IstioDistribution
+		goos              string
+		goarch            string
+		want              string
+	}{
+		"linux-amd64": {
+			istioDistribution: istioDistribution,
+			goos:              "linux",
+			goarch:            "amd64",
+			want:              "https://istio.tetratelabs.io/getmesh/files/istio-1.7.6-tetrate-v0-linux-amd64.tar.gz",
+		},
+		"linux-arm64": {
+			istioDistribution: istioDistribution,
+			goos:              "linux",
+			goarch:            "arm64",
+			want:              "https://istio.tetratelabs.io/getmesh/files/istio-1.7.6-tetrate-v0-linux-arm64.tar.gz",
+		},
+		"darwin-arm64": {
+			istioDistribution: istioDistribution,
+			goos:              "darwin",
+			goarch:            "arm64",
+			want:              "https://istio.tetratelabs.io/getmesh/files/istio-1.7.6-tetrate-v0-osx-arm64.tar.gz",
+		},
+		"darwin-amd64": {
+			istioDistribution: istioDistribution,
+			goos:              "darwin",
+			goarch:            "amd64",
+			want:              "https://istio.tetratelabs.io/getmesh/files/istio-1.7.6-tetrate-v0-osx.tar.gz", // No arch
+		},
+		"madeupoos-madeuparch": { //  Check that follows os-arch convention
+			istioDistribution: istioDistribution,
+			goos:              "madeupoos",
+			goarch:            "madeuparch",
+			want:              "https://istio.tetratelabs.io/getmesh/files/istio-1.7.6-tetrate-v0-madeupoos-madeuparch.tar.gz",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := fetchIstioctlURL(tc.istioDistribution, tc.goos, tc.goarch)
+			if tc.want != got {
+				t.Fatalf("expected: %v, got: %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support to fetch the correct `istioctl` binary for darwin-arm64.
Solves #64. 
Although #24 generates `getmesh` darwin-arm64 binaries, the generated binary wasn't fetching the correct `istioctl` for darwin-arm64.
 