### PR TITLE
add 1.11.6 to the manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 getmesh
 .idea
+.vscode

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -420,7 +420,7 @@ func checkUpgrade(t *testing.T) {
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run(), buf.String())
 	actual := buf.String()
-	require.Contains(t, actual, "1.11.3-tetrate-v0 is the latest version in 1.11-tetrate")
+	require.Contains(t, actual, "1.11.6-tetrate-v0 is the latest version in 1.11-tetrate")
 
 	// change image to 1.8.1-tetrate-v0
 	image := "containers.istio.tetratelabs.com/pilot:1.8.1-tetrate-v0"

--- a/site/manifest.json
+++ b/site/manifest.json
@@ -8,7 +8,22 @@
     "1.6": "2020-11-21"
   },
   "istio_distributions": [
-   {
+    {
+      "version": "1.11.6",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.6/"
+      ],
+      "is_security_patch": false
+    },
+    {
       "version": "1.11.3",
       "flavor": "tetrate",
       "flavor_version": 0,
@@ -22,8 +37,23 @@
         "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.3/"
       ],
       "is_security_patch": false
-   },
-   {
+    },
+    {
+      "version": "1.11.6",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.6/"
+      ],
+      "is_security_patch": false
+    },
+    {
       "version": "1.11.3",
       "flavor": "tetratefips",
       "flavor_version": 0,
@@ -263,7 +293,7 @@
       ],
       "is_security_patch": true
     },
-	{
+    {
       "version": "1.8.6",
       "flavor": "istio",
       "flavor_version": 0,
@@ -278,7 +308,7 @@
       ],
       "is_security_patch": true
     },
-	{
+    {
       "version": "1.8.5",
       "flavor": "tetrate",
       "flavor_version": 0,


### PR DESCRIPTION
Adds the 1.11.6 build, which also fixes CVEs (https://github.com/tetratelabs/istio/pull/606)