### PR TITLE
fix e2e for EOL version

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -414,6 +414,11 @@ func versionTest(t *testing.T) {
 }
 
 func checkUpgrade(t *testing.T) {
+	// Override the manifest so 1.8 will always be supported
+	if err := os.Setenv("GETMESH_TEST_MANIFEST_PATH", "e2e/testdata/check-upgrade-manifest.json"); err != nil {
+		log.Fatal(err)
+	}
+
 	cmd := exec.Command("./getmesh", "check-upgrade")
 	buf := new(bytes.Buffer)
 	cmd.Stdout = buf

--- a/e2e/testdata/check-upgrade-manifest.json
+++ b/e2e/testdata/check-upgrade-manifest.json
@@ -1,0 +1,415 @@
+{
+  "istio_minor_versions_eol_dates": {
+    "1.11": "2022-10-11",
+    "1.10": "2022-07-17",
+    "1.9": "2022-04-08",
+    "1.8": "2092-01-18",
+    "1.7": "2021-10-20",
+    "1.6": "2020-11-21"
+  },
+  "istio_distributions": [
+    {
+      "version": "1.11.6",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.6/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.11.3",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.11.6",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.6/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.11.3",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.11.3",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.11.x/announcing-1.11.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.10.3",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.10.x/announcing-1.10.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.10.3",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.10.x/announcing-1.10.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.10.3",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.10.x/announcing-1.10.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.7",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9.7/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.7",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9.7/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.7",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9.7/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.5",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9.5/"
+      ],
+      "is_security_patch": true
+    },
+    {
+      "version": "1.9.5",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9.5/"
+      ],
+      "is_security_patch": true
+    },
+    {
+      "version": "1.9.4",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9.4/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.4",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9.4/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.0",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.0",
+      "flavor": "tetratefips",
+      "flavor_version": 1,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.9.0",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.17",
+        "1.18",
+        "1.19",
+        "1.20"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.9.x/announcing-1.9/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.8.6",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18",
+        "1.19"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.8.x/announcing-1.8.6/"
+      ],
+      "is_security_patch": true
+    },
+    {
+      "version": "1.8.6",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18",
+        "1.19"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.8.x/announcing-1.8.6/"
+      ],
+      "is_security_patch": true
+    },
+    {
+      "version": "1.8.5",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18",
+        "1.19"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.8.x/announcing-1.8.5/"
+      ],
+      "is_security_patch": true
+    },
+    {
+      "version": "1.8.5",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18",
+        "1.19"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.8.x/announcing-1.8.5/"
+      ],
+      "is_security_patch": true
+    },
+    {
+      "version": "1.8.3",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18",
+        "1.19"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.8.x/announcing-1.8.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.8.3",
+      "flavor": "tetratefips",
+      "flavor_version": 1,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18",
+        "1.19"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.8.x/announcing-1.8.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.8.3",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18",
+        "1.19"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.8.x/announcing-1.8.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.7.8",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.7.x/announcing-1.7.8/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.7.8",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.16",
+        "1.17",
+        "1.18"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.7.x/announcing-1.7.8/"
+      ],
+      "is_security_patch": false
+    }
+  ]
+}


### PR DESCRIPTION
There is a test for `check-upgrade` that relies on Istio 1.8, which went EOL in January, and this is causing the test to fail.

I'm using a mocked manifest that will not report EOL for 1.8 so we can keep the test.