### PR TITLE
Publish 1.11.6-v1  to getmesh

### DIFF
--- a/site/manifest.json
+++ b/site/manifest.json
@@ -55,7 +55,7 @@
     {
       "version": "1.11.6",
       "flavor": "tetrate",
-      "flavor_version": 0,
+      "flavor_version": 1,
       "k8s_versions": [
         "1.17",
         "1.18",
@@ -85,7 +85,7 @@
     {
       "version": "1.11.6",
       "flavor": "tetratefips",
-      "flavor_version": 0,
+      "flavor_version": 1,
       "k8s_versions": [
         "1.17",
         "1.18",


### PR DESCRIPTION
Rebuilt 1.11.6 fips build again CGO enabled to utilize boringgo  crypto module.