### PR TITLE
Update github workflow to use Golang 1.17.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '1.17'
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -58,6 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.17.7'
 
       - name: addlicense
         run: go get github.com/google/addlicense
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '1.17.7'
 
       - uses: actions/cache@v2
         with:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.17.7'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '1.17.7'
 
       - uses: actions/cache@v2
         with:
@@ -109,7 +109,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '1.17.7'
 
       - uses: debianmaster/actions-k3s@master
         id: k3s

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -57,6 +57,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.7'
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -64,8 +64,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          skip-build-cache: true
-          skip-pkg-cache: true
+          skip-go-installation: true
           version: v1.29
           args: -v
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '1.17'
 
       - name: addlicense
         run: go get github.com/google/addlicense

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -58,12 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.7'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
+          skip-cache: true
           version: v1.29
           args: -v
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -64,7 +64,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          skip-cache: true
+          skip-build-cache: true
+          skip-pkg-cache: true
           version: v1.29
           args: -v
 


### PR DESCRIPTION
Workflows for  lint  job is failing for getmesh due to go version  1.18.
Currently we use use `go-version: '^1.16'`. This means any version greater than 1.16 are qualified.
GH ends up selecting 1.18, which causes some problem for golangci-lint.

Related GH issue.
https://github.com/golangci/golangci-lint/issues/2649
Downgrading it to 1.17 as possible remediation.
