### PR TITLE
Add END OF LIFE coloumn to `getmesh list`

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -72,11 +72,15 @@ func fetchManifest(url string) (*Manifest, error) {
 		return nil, fmt.Errorf("error unmarshalling fetched manifest: %v", err)
 	}
 
+	// Populate End of Life field within each distribution
+	if err := (&ret).SetEOLInIstioDistributions(); err != nil {
+		return nil, fmt.Errorf("error setting end of life in istio distribution: %v", err)
+	}
 	return &ret, nil
 }
 
 func PrintManifest(ms *Manifest, current *IstioDistribution) error {
-	column := []string{"ISTIO VERSION", "FLAVOR", "FLAVOR VERSION", "K8S VERSIONS"}
+	column := []string{"ISTIO VERSION", "FLAVOR", "FLAVOR VERSION", "K8S VERSIONS", "END OF LIFE"}
 	data := make([][]string, len(ms.IstioDistributions))
 	for i, m := range ms.IstioDistributions {
 		ps := strings.Join(m.K8SVersions, ",")
@@ -84,7 +88,7 @@ func PrintManifest(ms *Manifest, current *IstioDistribution) error {
 			m.Version = "*" + m.Version
 		}
 		data[i] = []string{m.Version, m.Flavor,
-			strconv.Itoa(int(m.FlavorVersion)), ps}
+			strconv.Itoa(int(m.FlavorVersion)), ps, m.EndOfLife}
 	}
 
 	table := tablewriter.NewWriter(logger.GetWriter())

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -84,12 +84,14 @@ func TestPrintManifest(t *testing.T) {
 					Flavor:        IstioDistributionFlavorTetrate,
 					FlavorVersion: 0,
 					K8SVersions:   []string{"1.16"},
+					EndOfLife:     "2022-01-01",
 				},
 				{
 					Version:       "1.7.5",
 					Flavor:        IstioDistributionFlavorTetrate,
 					FlavorVersion: 0,
 					K8SVersions:   []string{"1.16"},
+					EndOfLife:     "2022-01-01",
 				},
 			},
 		}
@@ -97,9 +99,9 @@ func TestPrintManifest(t *testing.T) {
 		buf := logger.ExecuteWithLock(func() {
 			require.NoError(t, PrintManifest(manifest, nil))
 		})
-		require.Equal(t, `ISTIO VERSION	FLAVOR 	FLAVOR VERSION	K8S VERSIONS	END OF LIFE
-    1.7.6    	tetrate	      0       	    1.16    	
-    1.7.5    	tetrate	      0       	    1.16    	
+		require.Equal(t, `ISTIO VERSION	FLAVOR 	FLAVOR VERSION	K8S VERSIONS	END OF LIFE 
+    1.7.6    	tetrate	      0       	    1.16    	2022-01-01 	
+    1.7.5    	tetrate	      0       	    1.16    	2022-01-01 	
 `,
 			buf.String())
 	})
@@ -118,18 +120,21 @@ func TestPrintManifest(t *testing.T) {
 					Flavor:        IstioDistributionFlavorIstio,
 					FlavorVersion: 0,
 					K8SVersions:   []string{"1.18"},
+					EndOfLife:     "2023-01-01",
 				},
 				{
 					Version:       "1.7.6",
 					Flavor:        IstioDistributionFlavorTetrateFIPS,
 					FlavorVersion: 0,
 					K8SVersions:   []string{"1.16"},
+					EndOfLife:     "2022-01-01",
 				},
 				{
 					Version:       "1.7.5",
 					Flavor:        IstioDistributionFlavorTetrate,
 					FlavorVersion: 0,
 					K8SVersions:   []string{"1.16"},
+					EndOfLife:     "2022-01-01",
 				},
 			},
 		}
@@ -138,10 +143,10 @@ func TestPrintManifest(t *testing.T) {
 			require.NoError(t, PrintManifest(manifest, current))
 		})
 
-		require.Equal(t, `ISTIO VERSION	  FLAVOR   	FLAVOR VERSION	K8S VERSIONS	END OF LIFE
-    1.8.3    	   istio   	      0       	    1.18    	
-   *1.7.6    	tetratefips	      0       	    1.16    	
-    1.7.5    	  tetrate  	      0       	    1.16    	
+		require.Equal(t, `ISTIO VERSION	  FLAVOR   	FLAVOR VERSION	K8S VERSIONS	END OF LIFE 
+    1.8.3    	   istio   	      0       	    1.18    	2023-01-01 	
+   *1.7.6    	tetratefips	      0       	    1.16    	2022-01-01 	
+    1.7.5    	  tetrate  	      0       	    1.16    	2022-01-01 	
 `,
 			buf.String())
 	})

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -97,7 +97,7 @@ func TestPrintManifest(t *testing.T) {
 		buf := logger.ExecuteWithLock(func() {
 			require.NoError(t, PrintManifest(manifest, nil))
 		})
-		require.Equal(t, `ISTIO VERSION	FLAVOR 	FLAVOR VERSION	K8S VERSIONS 
+		require.Equal(t, `ISTIO VERSION	FLAVOR 	FLAVOR VERSION	K8S VERSIONS	END OF LIFE
     1.7.6    	tetrate	      0       	    1.16    	
     1.7.5    	tetrate	      0       	    1.16    	
 `,
@@ -138,7 +138,7 @@ func TestPrintManifest(t *testing.T) {
 			require.NoError(t, PrintManifest(manifest, current))
 		})
 
-		require.Equal(t, `ISTIO VERSION	  FLAVOR   	FLAVOR VERSION	K8S VERSIONS 
+		require.Equal(t, `ISTIO VERSION	  FLAVOR   	FLAVOR VERSION	K8S VERSIONS	END OF LIFE
     1.8.3    	   istio   	      0       	    1.18    	
    *1.7.6    	tetratefips	      0       	    1.16    	
     1.7.5    	  tetrate  	      0       	    1.16    	

--- a/internal/manifest/type_test.go
+++ b/internal/manifest/type_test.go
@@ -580,3 +580,29 @@ func TestGetLatestDistribution(t *testing.T) {
 		})
 	}
 }
+
+func TestEOLInIstioDistributions(t *testing.T) {
+	ms := &Manifest{
+		IstioDistributions: []*IstioDistribution{
+			{
+				Version:       "1.8.1",
+				Flavor:        IstioDistributionFlavorTetrate,
+				FlavorVersion: 10,
+				K8SVersions:   []string{"1.16"},
+			},
+			{
+				Version:       "1.7.5",
+				Flavor:        IstioDistributionFlavorTetrate,
+				FlavorVersion: 0,
+				K8SVersions:   []string{"1.16"},
+			},
+		},
+		IstioMinorVersionsEOLDates: map[string]string{
+			"1.7": "2022-01-01",
+			"1.8": "2023-01-01",
+		},
+	}
+	require.NoError(t, ms.SetEOLInIstioDistributions())
+	require.Equal(t, "2023-01-01", ms.IstioDistributions[0].EndOfLife)
+	require.Equal(t, "2022-01-01", ms.IstioDistributions[1].EndOfLife)
+}


### PR DESCRIPTION
```
ISTIO VERSION	  FLAVOR   	FLAVOR VERSION	   K8S VERSIONS    	END OF LIFE 
   *1.17.0   	  tetrate  	      0       	1.23,1.24,1.25,1.26	2024-08-14 	
   1.17.0    	   istio   	      0       	1.23,1.24,1.25,1.26	2024-08-14 	
   1.16.2    	  tetrate  	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.2    	tetratefips	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.2    	   istio   	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.1    	  tetrate  	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.1    	tetratefips	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.1    	   istio   	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.0    	  tetrate  	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.0    	tetratefips	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.16.0    	   istio   	      0       	1.22,1.23,1.24,1.25	2024-01-15 	
   1.15.4    	  tetrate  	      0       	1.22,1.23,1.24,1.25	2023-10-31 	
   1.15.4    	tetratefips	      0       	1.22,1.23,1.24,1.25	2023-10-31 	
```