### PR TITLE
publish release

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -421,7 +421,7 @@ func checkUpgrade(t *testing.T) {
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run(), buf.String())
 	actual := buf.String()
-	require.Contains(t, actual, "1.17.2-tetrate-v0 is the latest version in 1.17-tetrate")
+	require.Contains(t, actual, "1.18.0-tetrate-v0 is the latest version in 1.18-tetrate")
 
 	// change image to 1.8.1-tetrate-v0
 	image := "containers.istio.tetratelabs.com/pilot:1.12.2-tetrate-v0"
@@ -440,7 +440,7 @@ func checkUpgrade(t *testing.T) {
 		_ = cmd.Run()
 		actual := buf.String()
 		return strings.Contains(actual,
-			"1.17.2-tetrate-v0 is the latest version in 1.17-tetrate")
+			"1.18.0-tetrate-v0 is the latest version in 1.18-tetrate")
 	}, time.Minute, 3*time.Second)
 }
 

--- a/site/manifest.json
+++ b/site/manifest.json
@@ -1,5 +1,6 @@
 {
   "istio_minor_versions_eol_dates": {
+    "1.18": "2024-12-07",
     "1.17": "2024-08-14",
     "1.16": "2024-01-15",
     "1.15": "2023-10-31",
@@ -10,6 +11,98 @@
     "1.10": "2022-03-07"
   },
   "istio_distributions": [
+    {
+      "version": "1.18.0",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.23",
+        "1.24",
+        "1.25",
+        "1.26"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.18.x/announcing-1.18/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.18.0",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.23",
+        "1.24",
+        "1.25",
+        "1.26"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.18.x/announcing-1.18/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.18.0",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.23",
+        "1.24",
+        "1.25",
+        "1.26"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.18.x/announcing-1.18/"
+      ],
+      "is_security_patch": false
+    },
+
+    {
+      "version": "1.17.3",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.23",
+        "1.24",
+        "1.25",
+        "1.26"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.17.x/announcing-1.17.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.17.3",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.23",
+        "1.24",
+        "1.25",
+        "1.26"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.17.x/announcing-1.17.3/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.17.3",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.23",
+        "1.24",
+        "1.25",
+        "1.26"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.17.x/announcing-1.17.3/"
+      ],
+      "is_security_patch": false
+    },
+
         {
       "version": "1.17.2",
       "flavor": "tetrate",
@@ -127,6 +220,51 @@
       ],
       "release_notes": [
         "https://istio.io/latest/news/releases/1.17.x/announcing-1.17/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.16.5",
+      "flavor": "tetrate",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.22",
+        "1.23",
+        "1.24",
+        "1.25"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.16.x/announcing-1.16.5/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.16.5",
+      "flavor": "tetratefips",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.22",
+        "1.23",
+        "1.24",
+        "1.25"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.16.x/announcing-1.16.5/"
+      ],
+      "is_security_patch": false
+    },
+    {
+      "version": "1.16.5",
+      "flavor": "istio",
+      "flavor_version": 0,
+      "k8s_versions": [
+        "1.22",
+        "1.23",
+        "1.24",
+        "1.25"
+      ],
+      "release_notes": [
+        "https://istio.io/latest/news/releases/1.16.x/announcing-1.16.5/"
       ],
       "is_security_patch": false
     },


### PR DESCRIPTION
Publish recentl TID releases to getmesh
- 1.18.0
- 1.17.3
- 1.16.5